### PR TITLE
types: add felt.Bytes

### DIFF
--- a/types/felt.go
+++ b/types/felt.go
@@ -32,6 +32,12 @@ func (f *Felt) Big() *big.Int {
 	return new(big.Int).SetBytes(f.Int.Bytes())
 }
 
+func (f *Felt) Bytes() []byte {
+	ret := [32]byte{}
+	f.Int.FillBytes(ret[:])
+	return ret[:]
+}
+
 // StrToFelt converts a string containing a decimal, hexadecimal or UTF8 charset into a Felt.
 func StrToFelt(str string) *Felt {
 	f := new(Felt)
@@ -70,7 +76,7 @@ func BytesToFelt(b []byte) *Felt {
 
 // String converts a Felt into its 'short string' representation.
 func (f *Felt) ShortString() string {
-	str := string(f.Bytes())
+	str := string(f.Int.Bytes())
 	if asciiRegexp.MatchString(str) {
 		return str
 	}

--- a/types/felt_test.go
+++ b/types/felt_test.go
@@ -1,9 +1,9 @@
 package types
 
 import (
-	"fmt"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"strconv"
 	"testing"
@@ -26,9 +26,9 @@ var (
 var feltTest FeltTest
 
 type FeltTest struct {
-	MaxFelt *big.Int    `json:"max_felt"`
-	LongString string `json:"long_string"`
-	Felts   []FeltValue `json:"felts"`
+	MaxFelt    *big.Int    `json:"max_felt"`
+	LongString string      `json:"long_string"`
+	Felts      []FeltValue `json:"felts"`
 }
 
 type FeltValue struct {
@@ -117,5 +117,13 @@ func TestGQLMarshal(t *testing.T) {
 		if buf.String() != strconv.Quote(cmp.String()) {
 			t.Errorf("Could not marshal GQL for felt: %v %v\n", buf.String(), strconv.Quote(cmp.String()))
 		}
+	}
+}
+
+func TestBytes(t *testing.T) {
+	feltBytes := StrToFelt("0x010203").Bytes()
+	expectedBytes := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3}
+	if !bytes.Equal(expectedBytes, feltBytes) {
+		t.Errorf("Byte slices are not equal:\nExpected: %v\nGot: %v\n", expectedBytes, feltBytes)
 	}
 }


### PR DESCRIPTION
another option could be to rename it from `Bytes()`.. since there might be callers that rely on its previous behavior of calling `big.Int.Bytes()`